### PR TITLE
add basic source option for loading template files

### DIFF
--- a/lib/deas-kramdown/source.rb
+++ b/lib/deas-kramdown/source.rb
@@ -1,0 +1,57 @@
+require 'pathname'
+require 'kramdown'
+
+module Deas; end
+module Deas::Kramdown
+
+  class Source
+
+    attr_reader :root, :cache, :doc_opts
+
+    def initialize(root, opts)
+      @root     = Pathname.new(root.to_s)
+      @doc_opts = opts[:doc_opts] || {}
+      @cache    = opts[:cache] ? Hash.new : NullCache.new
+    end
+
+    def render(template_name)
+      load(template_name).to_html
+    end
+
+    def compile(template_name, content)
+      doc(content).to_html
+    end
+
+    def doc(content)
+      Kramdown::Document.new(content, @doc_opts)
+    end
+
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)}"\
+      " @root=#{@root.inspect}"\
+      " @doc_opts=#{@doc_opts.inspect}>"
+    end
+
+    private
+
+    def load(template_name)
+      @cache[template_name] ||= begin
+        file_path = source_file_path(template_name).to_s
+        content = File.send(File.respond_to?(:binread) ? :binread : :read, file_path)
+        doc(content)
+      end
+    end
+
+    def source_file_path(template_name)
+      Dir.glob(self.root.join("#{template_name}*")).first
+    end
+
+    class NullCache
+      def [](template_name);         end
+      def []=(template_name, value); end
+      def keys; [];                  end
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,15 @@
 # this file is automatically required when you run `assert`
 # put any test helpers here
 
+require 'pathname'
+
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+ROOT = Pathname.new(File.expand_path("../..", __FILE__))
+$LOAD_PATH.unshift(ROOT.to_s)
+
+TEST_SUPPORT_PATH = ROOT.join('test/support')
+TEMPLATE_ROOT = TEST_SUPPORT_PATH.join('templates')
+TEMPLATE_CACHE_ROOT = ROOT.join('tmp/templates')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,16 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.template_root
+    TEMPLATE_ROOT.to_s
+  end
+
+  def self.template_file(name)
+    TEMPLATE_ROOT.join(name).to_s
+  end
+
+  def self.basic_markdown_rendered
+    "<h1 id=\"some-heading\">Some Heading</h1>\n"
+  end
+
 end

--- a/test/support/templates/basic.html.md
+++ b/test/support/templates/basic.html.md
@@ -1,0 +1,1 @@
+# Some Heading

--- a/test/support/templates/basic_alt.markdown
+++ b/test/support/templates/basic_alt.markdown
@@ -1,0 +1,1 @@
+# Some Heading

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -1,0 +1,145 @@
+require 'assert'
+require 'deas-kramdown/source'
+
+require 'kramdown'
+
+class Deas::Kramdown::Source
+
+  class UnitTests < Assert::Context
+    desc "Deas::Kramdown::Source"
+    setup do
+      @source_class = Deas::Kramdown::Source
+    end
+    subject{ @source_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @doc_opts = { Factory.string => Factory.string }
+      @root = Factory.template_root
+      @source = @source_class.new(@root, :doc_opts => @doc_opts)
+    end
+    subject{ @source }
+
+    should have_readers :root, :cache, :doc_opts
+    should have_imeths :render, :compile, :doc
+
+    should "know its root" do
+      assert_equal @root, subject.root.to_s
+    end
+
+    should "not cache templates by default" do
+      assert_kind_of NullCache, subject.cache
+    end
+
+    should "cache templates if the :cache opt is `true`" do
+      source = @source_class.new(@root, :cache => true)
+      assert_kind_of Hash, source.cache
+    end
+
+    should "know its doc options" do
+      assert_equal @doc_opts, subject.doc_opts
+      assert_equal Hash.new,  @source_class.new(@root, {}).doc_opts
+    end
+
+    should "build kramdown doc objects from template content" do
+      content  = '# Some Heading'
+      kdoc = Kramdown::Document.new(content, @doc_opts)
+      kdoc_called_with = []
+      Assert.stub(Kramdown::Document, :new) do |*args|
+        kdoc_called_with = args
+        kdoc
+      end
+
+      doc = subject.doc(content)
+      assert_instance_of Kramdown::Document, doc
+
+      exp = [content, @doc_opts]
+      assert_equal exp, kdoc_called_with
+    end
+
+  end
+
+  class RenderTests < InitTests
+    desc "`render` method"
+    setup do
+      @template_name = ['basic', 'basic_alt'].choice
+    end
+
+    should "render a template for the given template name and return its data" do
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, subject.render(@template_name)
+    end
+
+  end
+
+  class RenderCacheTests < RenderTests
+    desc "when caching is enabled"
+    setup do
+      @source = @source_class.new(@root, :cache => true)
+    end
+
+    should "cache templates by their template name" do
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, @source.render(@template_name)
+
+      assert_equal [@template_name], @source.cache.keys
+      assert_kind_of Kramdown::Document, @source.cache[@template_name]
+    end
+
+  end
+
+  class RenderNoCacheTests < RenderTests
+    desc "when caching is disabled"
+    setup do
+      @source = @source_class.new(@root, :cache => false)
+    end
+
+    should "not cache templates" do
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, @source.render(@template_name)
+
+      assert_equal [], @source.cache.keys
+    end
+
+  end
+
+  class CompileTests < InitTests
+    desc "`compile` method"
+
+    should "evaluate raw template output and return it" do
+      raw = "## Another Heading"
+      exp = "<h2 id=\"another-heading\">Another Heading</h2>\n"
+      assert_equal exp, subject.compile('compile', raw)
+    end
+
+  end
+
+  class NullCacheTests < UnitTests
+    desc "NullCache"
+    setup do
+      @cache = NullCache.new
+    end
+    subject{ @cache }
+
+    should have_imeths :[], :[]=, :keys
+
+    should "take a template name and return nothing on index" do
+      assert_nil subject[Factory.path]
+    end
+
+    should "take a template name and value and do nothing on index write" do
+      assert_nothing_raised do
+        subject[Factory.path] = Factory.string
+      end
+    end
+
+    should "always have empty keys" do
+      assert_equal [], subject.keys
+    end
+
+  end
+
+end


### PR DESCRIPTION
This class models the root that template files will be loaded from
and implements how they will be rendered and compiled.  This will
be used by the engine to implement the Deas rendering API.

All this really does is wrap calls to `Kramdown::Document` and allows
optionally caching template content.  This closely follows the pattern
setup by deas-erubis.

@jcredding ready for review.
