### PR TITLE
basic template engine

### DIFF
--- a/deas-kramdown.gemspec
+++ b/deas-kramdown.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("deas",     ["~> 0.39.1"])
+  gem.add_dependency("deas",     ["~> 0.39.2"])
   gem.add_dependency("kramdown", ["~> 1.10"])
 
 end

--- a/lib/deas-kramdown.rb
+++ b/lib/deas-kramdown.rb
@@ -1,5 +1,38 @@
+require 'deas/template_engine'
+require 'kramdown'
+
 require "deas-kramdown/version"
+require 'deas-kramdown/source'
 
 module Deas::Kramdown
-  # TODO: your code goes here...
+
+  class TemplateEngine < Deas::TemplateEngine
+
+    def kramdown_source
+      @kramdown_source ||= Source.new(self.source_path, {
+        :doc_opts => self.opts['doc_opts'],
+        :cache    => self.opts['cache']
+      })
+    end
+
+    # Render straight markdown templates.  As no ruby will be evaluated the view
+    # handler, locals and content block will be ignored.
+    def render(template_name, view_handler, locals, &content)
+      self.kramdown_source.render(template_name)
+    end
+
+    # Render straight markdown partial templates.  As no ruby will be evaluated
+    # the locals and content block will be ignored.
+    def partial(template_name, locals, &content)
+      self.kramdown_source.render(template_name)
+    end
+
+    # this is used when chaining engines where another engine initially loads the
+    # template file
+    def compile(template_name, compiled_content)
+      self.kramdown_source.compile(template_name, compiled_content)
+    end
+
+  end
+
 end

--- a/test/support/templates/_basic.md
+++ b/test/support/templates/_basic.md
@@ -1,0 +1,1 @@
+# Some Heading

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -1,0 +1,45 @@
+require 'assert'
+require 'deas-kramdown'
+
+require 'deas/template_source'
+
+class Deas::Kramdown::TemplateEngine
+
+  class SystemTests < Assert::Context
+    desc "Deas::Kramdown::TemplateEngine"
+    setup do
+      @view = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name       => Factory.string
+      })
+      @locals  = { 'local1' => Factory.string }
+      @content = Proc.new{ Factory.string }
+
+      @engine = Deas::Kramdown::TemplateEngine.new('source_path' => TEMPLATE_ROOT)
+    end
+    subject{ @engine }
+
+    should "render templates (ignoring the view/locals/content)" do
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, subject.render('basic', @view, @locals)
+      assert_equal exp, subject.render('basic', @view, @locals, &@content)
+    end
+
+    should "render partial templates (ignoring the locals/content)" do
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, subject.partial('_basic', @locals)
+      assert_equal exp, subject.partial('_basic', @locals, &@content)
+    end
+
+    should "compile raw template markup" do
+      template_name = 'basic_alt'
+      file_path     = TEMPLATE_ROOT.join("#{template_name}.markdown").to_s
+      file_content  = File.read(file_path)
+
+      exp = Factory.basic_markdown_rendered
+      assert_equal exp, subject.compile(template_name, file_content)
+    end
+
+  end
+
+end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,0 +1,46 @@
+require 'assert'
+require 'deas-kramdown'
+
+require 'deas/template_engine'
+require 'deas-kramdown/source'
+
+class Deas::Kramdown::TemplateEngine
+
+  class UnitTests < Assert::Context
+    desc "Deas::Kramdown::TemplateEngine"
+    setup do
+      @engine = Deas::Kramdown::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH
+      })
+    end
+    subject{ @engine }
+
+    should have_imeths :kramdown_source
+    should have_imeths :render, :partial, :compile
+
+    should "be a Deas template engine" do
+      assert_kind_of Deas::TemplateEngine, subject
+    end
+
+    should "memoize its kramdown source" do
+      assert_kind_of Deas::Kramdown::Source, subject.kramdown_source
+      assert_equal subject.source_path, subject.kramdown_source.root
+      assert_same subject.kramdown_source, subject.kramdown_source
+    end
+
+    should "allow custom doc opts on its source" do
+      doc_opts = { Factory.string => Factory.string }
+      engine = Deas::Kramdown::TemplateEngine.new('doc_opts' => doc_opts)
+      assert_equal doc_opts, engine.kramdown_source.doc_opts
+    end
+
+    should "pass any given cache option to its source" do
+      engine = Deas::Kramdown::TemplateEngine.new('cache' => true)
+      assert_kind_of Hash, engine.kramdown_source.cache
+    end
+
+  end
+
+  # render, partial and compile tests are covered in the system tests
+
+end


### PR DESCRIPTION
This implements a Deas template engine for rendering markdown templates
with Kramdown.  This implements the render/partial/compile API
Deas expects using the deas-kramdown source object.  Since no ruby
will be evaluated, the view/locals/content will always be ignored.

This also updates to the latest version of Deas which supports
multi-engine templates.

@jcredding ready for review.
