### PR TITLE
get working in modern ruby versions

### DIFF
--- a/deas-kramdown.gemspec
+++ b/deas-kramdown.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("deas",     ["~> 0.40.0"])
+  gem.add_dependency("deas",     ["~> 0.41.0"])
   gem.add_dependency("kramdown", ["~> 1.10"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,4 +16,11 @@ require 'pry'
 
 require 'test/support/factory'
 
-# TODO: put test helpers here...
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -65,7 +65,7 @@ class Deas::Kramdown::Source
   class RenderTests < InitTests
     desc "`render` method"
     setup do
-      @template_name = ['basic', 'basic_alt'].choice
+      @template_name = ['basic', 'basic_alt'].sample
     end
 
     should "render a template for the given template name and return its data" do


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

@jcredding ready for review.
